### PR TITLE
Switch base image to registry.access.redhat.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/centos/httpd-24-centos7:latest
+FROM registry.access.redhat.com/rhscl/httpd-24-rhel7:latest
 
 COPY src/ /tmp/src/
 


### PR DESCRIPTION
Docker Hub has started to rate limit public image pulls.

registry.access.redhat.com is accessible without authentication.